### PR TITLE
Fix #4 Improved exception reporting: Entire exception instead of message only.

### DIFF
--- a/Machine.Specifications.ConsoleRunner/ExceptionReporter.cs
+++ b/Machine.Specifications.ConsoleRunner/ExceptionReporter.cs
@@ -13,7 +13,7 @@ namespace Machine.Specifications.ConsoleRunner
 
         public void ReportException(Exception ex)
         {
-            _console.WriteLine(ex.Message);
+            _console.WriteLine("{0}", ex);
         }
     }
 }

--- a/history.txt
+++ b/history.txt
@@ -1,2 +1,3 @@
-Machine.Specifications.Runner.Console x
+Machine.Specifications.Runner.Console 0.9.1
 -----------------------------
+-improved reporting in case of unhandled exception: instead of only Exception.Message, entire Exception with stack-trace is printed to the console.


### PR DESCRIPTION
The `ExceptionReporter` now prints the full exception, including stack trace, to the console.
This is intended to fix #4 
